### PR TITLE
CLARIFS: sat res 305m not 5km (z9) + 19m not 5m (z13) + downloads 2X faster (on "Install IIAB Maps" page)

### DIFF
--- a/osm-source/pages/installer/build/index.html
+++ b/osm-source/pages/installer/build/index.html
@@ -76,7 +76,7 @@ http://box/osm-vector-maps/installer/
         <!--/div-->
         <!--<div id='instr'></div>-->
         <h4><div id='cmdline_element' class="command"></div></h4>
-        Hit [Enter] to run it (sudo may request your password!)  You'll know it's downloaded and installed when http://box/maps shows Satellite Photos up to 14 levels of zoom (5 x 5 m pixels) &mdash; instead of just 10 levels of zoom (500 x 500 m pixels) &mdash; within the (square) local region you chose above.  Thanks for your patience!
+        Hit [Enter] to run it (sudo may request your password!)  You'll know it's downloaded and installed when http://box/maps shows Satellite Photos up to 14 levels of zoom (38 x 38 m pixels) &mdash; instead of just 10 levels of zoom (306 x 306 m pixels) &mdash; within the (square) local region you chose above.  Thanks for your patience!
 
         <div class='grower'></div>
         <!--<div class="col-sm-2"><button id="DNLD-SAT" type="button" class="btn btn-lg btn-primary">Download More Satellite Data</button></div>-->

--- a/osm-source/pages/installer/build/index.html
+++ b/osm-source/pages/installer/build/index.html
@@ -58,15 +58,15 @@ http://box/osm-vector-maps/installer/
           <div id='area-choice'>
             <div>
               <input type='radio' id='small' name='size' value='small'>
-              <label>100 x 100 km ~ 10 MB ~ 10 min download</label>
+              <label>100 x 100 km ~ 10 MB ~ 5 min download</label>
             </div>
             <div>
               <input type='radio' id='medium' name='size' value='medium'>
-              <label>300 x 300 km ~ 100 MB ~ 1 hour download</label>
+              <label>300 x 300 km ~ 100 MB ~ 0.5 hour download</label>
             </div>
             <div>
               <input type='radio' id='large' name='size' checked value='large'>
-              <label>1000 x 1000 km ~ 1 GB ~ 10 hour download</label>
+              <label>1000 x 1000 km ~ 1 GB ~ 5 hour download</label>
             </div>
         </span>
 
@@ -76,7 +76,7 @@ http://box/osm-vector-maps/installer/
         <!--/div-->
         <!--<div id='instr'></div>-->
         <h4><div id='cmdline_element' class="command"></div></h4>
-        Hit [Enter] to run it (sudo may request your password!)  You'll know it's downloaded and installed when http://box/maps shows Satellite Photos up to 14 levels of zoom (5 x 5 m pixels) &mdash; instead of just 10 levels of zoom (5 x 5 km pixels) &mdash; within the (square) local region you chose above.  Thanks for your patience!
+        Hit [Enter] to run it (sudo may request your password!)  You'll know it's downloaded and installed when http://box/maps shows Satellite Photos up to 14 levels of zoom (5 x 5 m pixels) &mdash; instead of just 10 levels of zoom (500 x 500 m pixels) &mdash; within the (square) local region you chose above.  Thanks for your patience!
 
         <div class='grower'></div>
         <!--<div class="col-sm-2"><button id="DNLD-SAT" type="button" class="btn btn-lg btn-primary">Download More Satellite Data</button></div>-->

--- a/osm-source/pages/installer/build/index.html
+++ b/osm-source/pages/installer/build/index.html
@@ -76,7 +76,7 @@ http://box/osm-vector-maps/installer/
         <!--/div-->
         <!--<div id='instr'></div>-->
         <h4><div id='cmdline_element' class="command"></div></h4>
-        Hit [Enter] to run it (sudo may request your password!)  You'll know it's downloaded and installed when http://box/maps shows Satellite Photos up to 14 levels of zoom (19 x 19 m pixels) &mdash; instead of just 10 levels of zoom (306 x 306 m pixels) &mdash; within the (square) local region you chose above.  Thanks for your patience!
+        Hit [Enter] to run it (sudo may request your password!)  You'll know it's downloaded and installed when http://box/maps shows Satellite Photos up to 14 levels of zoom (19 x 19 m pixels) &mdash; instead of just 10 levels of zoom (305 x 305 m pixels) &mdash; within the (square) local region you chose above.  Thanks for your patience!
 
         <div class='grower'></div>
         <!--<div class="col-sm-2"><button id="DNLD-SAT" type="button" class="btn btn-lg btn-primary">Download More Satellite Data</button></div>-->

--- a/osm-source/pages/installer/build/index.html
+++ b/osm-source/pages/installer/build/index.html
@@ -76,7 +76,7 @@ http://box/osm-vector-maps/installer/
         <!--/div-->
         <!--<div id='instr'></div>-->
         <h4><div id='cmdline_element' class="command"></div></h4>
-        Hit [Enter] to run it (sudo may request your password!)  You'll know it's downloaded and installed when http://box/maps shows Satellite Photos up to 14 levels of zoom (38 x 38 m pixels) &mdash; instead of just 10 levels of zoom (306 x 306 m pixels) &mdash; within the (square) local region you chose above.  Thanks for your patience!
+        Hit [Enter] to run it (sudo may request your password!)  You'll know it's downloaded and installed when http://box/maps shows Satellite Photos up to 14 levels of zoom (19 x 19 m pixels) &mdash; instead of just 10 levels of zoom (306 x 306 m pixels) &mdash; within the (square) local region you chose above.  Thanks for your patience!
 
         <div class='grower'></div>
         <!--<div class="col-sm-2"><button id="DNLD-SAT" type="button" class="btn btn-lg btn-primary">Download More Satellite Data</button></div>-->


### PR DESCRIPTION
Tell the truth, and stop underselling ourselves on the "Install IIAB Maps" page http://box/osm-vector-maps/installer/

And this is better aligned with IIAB Maps doc https://github.com/iiab/iiab/wiki/IIAB-Maps (currently being overhauled).

Building on PRs #29 & #30.
For iiab/iiab#1605, iiab/iiab#2551 etc.
In preparation for [IIAB 7.2](https://github.com/iiab/iiab/wiki/IIAB-7.2-Release-Notes) release.