### PR TITLE
Satellite Photos: fewer MB than I thought, so post that on "Install IIAB Maps" page

### DIFF
--- a/osm-source/pages/installer/build/index.html
+++ b/osm-source/pages/installer/build/index.html
@@ -58,15 +58,15 @@ http://box/osm-vector-maps/installer/
           <div id='area-choice'>
             <div>
               <input type='radio' id='small' name='size' value='small'>
-              <label>100 x 100 km ~ 10 MB ~ 5 min download</label>
+              <label>100 x 100 km ~ 5 MB ~ 5 min download</label>
             </div>
             <div>
               <input type='radio' id='medium' name='size' value='medium'>
-              <label>300 x 300 km ~ 100 MB ~ 0.5 hour download</label>
+              <label>300 x 300 km ~ 50 MB ~ 0.5 hour download</label>
             </div>
             <div>
               <input type='radio' id='large' name='size' checked value='large'>
-              <label>1000 x 1000 km ~ 1 GB ~ 5 hour download</label>
+              <label>1000 x 1000 km ~ 500 MB ~ 5 hour download</label>
             </div>
         </span>
 


### PR DESCRIPTION
This PR posts approximations for the "Install IIAB Maps" page.

Background...after having downloaded 4 Hi-Res Satellite Photo Regions, these are my actual results using [iiab-extend-sat.py](https://github.com/iiab/maps/blob/master/osm-source/pages/viewer/scripts/iiab-extend-sat.py) :

- 4MB downloaded in 2min (100x100 km)
- 8MB downloaded in 3min (100x100 km)
- 48MB downloaded in 20min (300x300 km)
- 343MB downloaded in 212min (1000x1000 km)

Ref: https://github.com/iiab/iiab/issues/2553#issuecomment-701467488