### PR TITLE
Refine /usr/bin/iiab-install-map-region for *2020*.mbtiles & Contabo

### DIFF
--- a/osm-source/pages/viewer/scripts/iiab-install-map-region
+++ b/osm-source/pages/viewer/scripts/iiab-install-map-region
@@ -1,36 +1,46 @@
 #!/bin/bash
 
-# Download a Map Pack (3 .mbtiles files, as nec) for IIAB 7.2 w/o Admin Console
+# e.g. USAGE: /usr/bin/iiab-install-map-region osm_oceania_z11-z14_2020.mbtiles
+
+# Download a Map Pack (3 .mbtiles files, as nec) for IIAB 8.0 w/o Admin Console
 # https://github.com/iiab/iiab/blob/master/roles/osm-vector-maps/README.md
 # https://github.com/iiab/iiab/wiki/IIAB-Maps
 
-REGION=osm_san_jose_z11-z14_2019.mbtiles     # If called w/o parameter (20.3 MB)
+REGION=osm_san_jose_z11-z14_2020.mbtiles     # If called w/o parameter (30 MB)
 if [ $# -ne 0 ]; then
     REGION=$1    # Map Pack selected on page: http://box > "Install IIAB Maps"
 fi    # SCREENSHOT https://github.com/iiab/iiab/pull/2551#issuecomment-701649236
 
-OSM_PLANET=osm-planet_z0-z10_2020.mbtiles    # 1.74 GB
-SAT_PLANET=satellite_z0-z9_2020.mbtiles        # 931 MB
+OSM_PLANET=osm-planet_z0-z10_2020.mbtiles    # 2.0 GB
+SAT_PLANET=satellite_z0-z9_2020.mbtiles      # 1.2 GB
 
-OSM_PREVIEW=planet_z0-z6_2020.mbtiles        # 33.8 MB
-SAT_PREVIEW=satellite_z0-z6_2020.mbtiles       # 19.1 MB
+OSM_PREVIEW=planet_z0-z6_2020.mbtiles        # 48 MB
+SAT_PREVIEW=satellite_z0-z6_2020.mbtiles     # 25 MB
 
 WORKING_DIR=/library/working/maps
 TILES_DIR=/library/www/osm-vector-maps/viewer/tiles
+
+iiab_var_value() {
+    v1=$(grep "^$1:\s" /opt/iiab/iiab/vars/default_vars.yml 2> /dev/null | tail -1 | sed "s/^$1:\s\+//; s/#.*//; s/\s*$//; s/^\(['\"]\)\(.*\)\1$/\2/")
+    v2=$(grep "^$1:\s" /etc/iiab/local_vars.yml 2> /dev/null | tail -1 | sed "s/^$1:\s\+//; s/#.*//; s/\s*$//; s/^\(['\"]\)\(.*\)\1$/\2/")
+    [[ $v2 != "" ]] && echo $v2 || echo $v1    # [ "$v2" ] ALSO WORKS
+}
 
 install_mbtiles() {
     if [ -f $TILES_DIR/$1 ] ; then
         echo -e "ALREADY INSTALLED: $TILES_DIR/$1\n"
     else
-        grep -q '^maps_from_internet_archive:\s\+[tT]rue\b' /etc/iiab/local_vars.yml; loc_t=$?
-        grep -q '^maps_from_internet_archive:\s\+[fF]alse\b' /etc/iiab/local_vars.yml; loc_f=$?
-        grep -q '^maps_from_internet_archive:\s\+[tT]rue\b' /opt/iiab/iiab/vars/default_vars.yml; def_t=$?
-        # 0 means TRUE   1 means FALSE   2 means ERROR e.g. FILE DOESN'T EXIST
-        if [[ $loc_t = 0 || ($def_t = 0 && ! $loc_f = 0) ]]; then
-        #if grep -q '^maps_from_internet_archive: True' /etc/iiab/local_vars.yml ; then
-            wget -c https://archive.org/download/$1/$1 -P $WORKING_DIR
+        # grep -q '^maps_from_internet_archive:\s\+[tT]rue\b' /etc/iiab/local_vars.yml; loc_t=$?
+        # grep -q '^maps_from_internet_archive:\s\+[fF]alse\b' /etc/iiab/local_vars.yml; loc_f=$?
+        # grep -q '^maps_from_internet_archive:\s\+[tT]rue\b' /opt/iiab/iiab/vars/default_vars.yml; def_t=$?
+        # # 0 means TRUE   1 means FALSE   2 means ERROR e.g. FILE DOESN'T EXIST
+        # if [[ $loc_t = 0 || ($def_t = 0 && ! $loc_f = 0) ]]; then
+        # #if grep -q '^maps_from_internet_archive: True' /etc/iiab/local_vars.yml ; then
+        if [[ $(iiab_var_value maps_from_internet_archive) =~ ^[Tt]rue$ ]]; then    # Or regex: ^True|true$
+            wget -c https://archive.org/download/$1/$1 -P $WORKING_DIR    # 2022-04-30 WARNING: NOT ALL *2020*.mbtiles FILES ARE YET UPLOADED TO archive.org
         else
-            wget -c http://timmoody.com/iiab-files/maps/$1 -P $WORKING_DIR
+            #wget -c http://timmoody.com/iiab-files/maps/$1 -P $WORKING_DIR                                          # Bluehost became extremely slow
+            wget -c https://usc1.contabostorage.com/6ce80ee7cd3b4baba0fbb26a424b0b29:iiab-maps/$1 -P $WORKING_DIR    # Limited to ~80 Mbit/s, unlike rclone
         fi
 
         # FYI Bluehost (timmoody.com) erroneously 404's if full file is in


### PR DESCRIPTION
Thanks to @georgejhunt who kickstarted this work on 2022-04-14:

- https://github.com/iiab/maps/pull/45/files#diff-e35e6563b9495a22ad9967f1ce72a63daf15b4dc0551ea2827fdb6604bf983df

This PR finishes the job, modernizes, and updates in-line documentation.  So the CLI (command-line interface) remains available for those who need/want that, to install any OSM "continent" a.k.a. region.

This PR was tested with 3 different "continents" a.k.a. regions.  Looks good!

Building on:

- PR #45
- PR iiab/iiab#3192
- PR iiab/iiab#3204